### PR TITLE
Feature/rapp2 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A C library for processing RESOL VBus data.
 ## Contributors
 
 - [Daniel Wippermann](https://github.com/danielwippermann)
+- [Rapp2](https://github.com/Rapp2)
 
 
 ## Legal Notices

--- a/examples/Master.c
+++ b/examples/Master.c
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MASTER Master = { 0 };
+    __MASTER Master = {};
 
     if (Result == RESOLVBUS_OK) {
         Result = __Initialize(&Master);

--- a/examples/Master.c
+++ b/examples/Master.c
@@ -266,7 +266,10 @@ int main(int argc, char **argv)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MASTER Master = {};
+    __MASTER Master = {
+        .Decoder = RESOLVBUS_LIVEDECODER_INITIALIZER,
+        .Encoder = RESOLVBUS_LIVEENCODER_INITIALIZER,
+    };
 
     if (Result == RESOLVBUS_OK) {
         Result = __Initialize(&Master);

--- a/examples/Minion.c
+++ b/examples/Minion.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MINION Minion = { 0 };
+    __MINION Minion = {};
 
     if (Result == RESOLVBUS_OK) {
         Result = __Initialize(&Minion);
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
     }
 
     while (Result == RESOLVBUS_OK) {
-        uint8_t ReadBytes [128] = { 0 };
+        uint8_t ReadBytes [128] = {};
         size_t ReadLength = 0;
         if (Result == RESOLVBUS_OK) {
             // TODO: read from serial port / socket / ... with short timeout / non-blocking

--- a/examples/Minion.c
+++ b/examples/Minion.c
@@ -173,7 +173,10 @@ int main(int argc, char **argv)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MINION Minion = {};
+    __MINION Minion = {
+        .Decoder = RESOLVBUS_LIVEDECODER_INITIALIZER,
+        .Encoder = RESOLVBUS_LIVEENCODER_INITIALIZER,
+    };
 
     if (Result == RESOLVBUS_OK) {
         Result = __Initialize(&Minion);

--- a/include/ResolVBus.h
+++ b/include/ResolVBus.h
@@ -36,6 +36,10 @@
     ((sizeof (__Type__) + 3) >> 2)
 
 
+#define RESOLVBUS_LIVEENCODER_INITIALIZER { .BufferLength = 0, }
+#define RESOLVBUS_LIVEDECODER_INITIALIZER { .BufferIndex = 0, }
+
+
 
 //---------------------------------------------------------------------------
 // PUBLIC TYPEDEFS

--- a/include/ResolVBus.h
+++ b/include/ResolVBus.h
@@ -863,7 +863,7 @@ RESOLVBUS_RESULT ResolVBus_LiveEncoder_QueueDatagram(RESOLVBUS_LIVEENCODER *Enco
  * @param Encoder Encoder instance
  * @param DestinationAddress Destination address of the telegram
  * @param SourceAddress Source address of the telegram
- * @param MinorVersion Minor protocol version of the telegram (major version will always be 0x10)
+ * @param MinorVersion Minor protocol version of the telegram (major version will always be 0x30)
  * @param Command Command of the telegram
  * @param FrameCount Frame count of the telegram
  * @returns RESOLVBUS_OK if no error occurred

--- a/test/LiveDecoderTestSuite.c
+++ b/test/LiveDecoderTestSuite.c
@@ -15,9 +15,9 @@
 //---------------------------------------------------------------------------
 
 #define __PREAMBLE() \
-    RESOLVBUS_LIVEDECODER DecoderLocal = { 0 }; \
+    RESOLVBUS_LIVEDECODER DecoderLocal = {}; \
     RESOLVBUS_LIVEDECODER *Decoder = &DecoderLocal; \
-    uint8_t FrameDataBufferLocal [512] = { 0 }; \
+    uint8_t FrameDataBufferLocal [512] = {}; \
     __WRAP(ResolVBus_LiveDecoder_Initialize(Decoder, FrameDataBufferLocal, sizeof (FrameDataBufferLocal), __Handler)); \
     __HandlerLog [0] = 0; \
 

--- a/test/LiveDecoderTestSuite.c
+++ b/test/LiveDecoderTestSuite.c
@@ -15,9 +15,9 @@
 //---------------------------------------------------------------------------
 
 #define __PREAMBLE() \
-    RESOLVBUS_LIVEDECODER DecoderLocal = {}; \
+    RESOLVBUS_LIVEDECODER DecoderLocal = RESOLVBUS_LIVEDECODER_INITIALIZER; \
     RESOLVBUS_LIVEDECODER *Decoder = &DecoderLocal; \
-    uint8_t FrameDataBufferLocal [512] = {}; \
+    uint8_t FrameDataBufferLocal [512] = { 0 }; \
     __WRAP(ResolVBus_LiveDecoder_Initialize(Decoder, FrameDataBufferLocal, sizeof (FrameDataBufferLocal), __Handler)); \
     __HandlerLog [0] = 0; \
 
@@ -101,9 +101,9 @@ static RESOLVBUS_RESULT __TestDecodeShortFrameDataBuffer(void)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    RESOLVBUS_LIVEDECODER DecoderLocal = {};
+    RESOLVBUS_LIVEDECODER DecoderLocal = RESOLVBUS_LIVEDECODER_INITIALIZER;
     RESOLVBUS_LIVEDECODER *Decoder = &DecoderLocal;
-    uint8_t FrameDataBufferLocal [256] = {};
+    uint8_t FrameDataBufferLocal [256] = { 0 };
     __WRAP(ResolVBus_LiveDecoder_Initialize(Decoder, FrameDataBufferLocal, 2, __Handler));
     __HandlerLog [0] = 0;
     __ASSERT_EQL(Decoder->Event.FrameDataBufferLength, 2);

--- a/test/LiveEncoderTestSuite.c
+++ b/test/LiveEncoderTestSuite.c
@@ -20,7 +20,7 @@
 //---------------------------------------------------------------------------
 
 #define __PREAMBLE() \
-    RESOLVBUS_LIVEENCODER EncoderLocal = { 0 }; \
+    RESOLVBUS_LIVEENCODER EncoderLocal = RESOLVBUS_LIVEENCODER_INITIALIZER; \
     RESOLVBUS_LIVEENCODER *Encoder = &EncoderLocal; \
     uint8_t Buffer [512] = { 0 }; \
     __WRAP(ResolVBus_LiveEncoder_Initialize(Encoder, Buffer, sizeof (Buffer), __Handler)); \
@@ -513,8 +513,6 @@ static RESOLVBUS_RESULT __TestSuspendWithTimeoutAndCallback(void)
 
     __WRAP(ResolVBus_LiveEncoder_HandleTimer(Encoder, 0));
     __WRAP(ResolVBus_LiveEncoder_HandleTimer(Encoder, 10000));
-
-    __DLOG("PhaseTimeoutUs = %d", Encoder->PhaseTimeoutUs);
 
     __ASSERT_EQL(Encoder->Phase, RESOLVBUS_LIVEENCODERPHASE_SUSPENDEDWITHTIMEOUT);
     __ASSERT_EQL(Encoder->PhaseTimeoutUs, 250);

--- a/test/MasterExampleTest.c
+++ b/test/MasterExampleTest.c
@@ -101,7 +101,10 @@ RESOLVBUS_RESULT RunTest_MasterExample(void)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MASTER Master = {};
+    __MASTER Master = {
+        .Decoder = RESOLVBUS_LIVEDECODER_INITIALIZER,
+        .Encoder = RESOLVBUS_LIVEENCODER_INITIALIZER,
+    };
 
     __WRAP(__Initialize(&Master));
 

--- a/test/MasterExampleTest.c
+++ b/test/MasterExampleTest.c
@@ -101,7 +101,7 @@ RESOLVBUS_RESULT RunTest_MasterExample(void)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MASTER Master = { 0 };
+    __MASTER Master = {};
 
     __WRAP(__Initialize(&Master));
 

--- a/test/MinionExampleTest.c
+++ b/test/MinionExampleTest.c
@@ -101,7 +101,7 @@ RESOLVBUS_RESULT RunTest_MinionExample(void)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MINION Minion = { 0 };
+    __MINION Minion = {};
 
     __WRAP(__Initialize(&Minion));
 

--- a/test/MinionExampleTest.c
+++ b/test/MinionExampleTest.c
@@ -101,7 +101,10 @@ RESOLVBUS_RESULT RunTest_MinionExample(void)
 {
     RESOLVBUS_RESULT Result = RESOLVBUS_OK;
 
-    __MINION Minion = {};
+    __MINION Minion = {
+        .Decoder = RESOLVBUS_LIVEDECODER_INITIALIZER,
+        .Encoder = RESOLVBUS_LIVEENCODER_INITIALIZER,
+    };
 
     __WRAP(__Initialize(&Minion));
 

--- a/test/TestMain.c
+++ b/test/TestMain.c
@@ -19,6 +19,14 @@
 // PRIVATE DEFINES
 //---------------------------------------------------------------------------
 
+#ifdef __APPLE__
+#define __FORMAT_D64 "%lld"
+#define __FORMAT_X64 "0x%llX"
+#else
+#define __FORMAT_D64 "%ld"
+#define __FORMAT_X64 "0x%lX"
+#endif
+
 
 
 //---------------------------------------------------------------------------
@@ -61,7 +69,7 @@ static RESOLVBUS_RESULT __TestAssertEql(void)
 
     __WRAP(AssertEql(123, "LeftValue123", 123, "RightValue123"));
 
-    __ASSERT_RESULT_EQL(UNKNOWN, "Expected values to equal\n  Left:  LeftValue123 = 123 (0x7b)\n  Right: RightValue234 = 234 (0xea)\n\nBacktrace:\n", AssertEql(123, "LeftValue123", 234, "RightValue234"));
+    __ASSERT_RESULT_EQL(UNKNOWN, "Expected values to equal\n  Left:  LeftValue123 = 123 (0x7B)\n  Right: RightValue234 = 234 (0xEA)\n\nBacktrace:\n", AssertEql(123, "LeftValue123", 234, "RightValue234"));
 
     return Result;
 }
@@ -127,7 +135,7 @@ RESOLVBUS_RESULT AssertEql(int64_t LeftValue, const char *LeftExpr, int64_t Righ
 
     if (LeftValue != RightValue) {
         static char Message [1024] = { 0 };
-        snprintf(Message, sizeof (Message), "Expected values to equal\n  Left:  %s = %lld (0x%llx)\n  Right: %s = %lld (0x%llx)", LeftExpr, LeftValue, LeftValue, RightExpr, RightValue, RightValue);
+        snprintf(Message, sizeof (Message), "Expected values to equal\n  Left:  %s = " __FORMAT_D64 " (" __FORMAT_X64 ")\n  Right: %s = " __FORMAT_D64 " (" __FORMAT_X64 ")", LeftExpr, LeftValue, LeftValue, RightExpr, RightValue, RightValue);
 
         Result = RESOLVBUS_ERROR_UNKNOWN;
         ResolVBus_ResetBacktrace(Message, "<see above>", __FILE__, __LINE__, __func__);
@@ -142,7 +150,7 @@ RESOLVBUS_RESULT AssertNotEql(int64_t LeftValue, const char *LeftExpr, int64_t R
 
     if (LeftValue == RightValue) {
         static char Message [1024] = { 0 };
-        snprintf(Message, sizeof (Message), "Expected values not to equal\n  Left:  %s = %lld (0x%llx)\n  Right: %s = %lld (0x%llx)", LeftExpr, LeftValue, LeftValue, RightExpr, RightValue, RightValue);
+        snprintf(Message, sizeof (Message), "Expected values not to equal\n  Left:  %s = " __FORMAT_D64 " (" __FORMAT_X64 ")\n  Right: %s = " __FORMAT_D64 " (" __FORMAT_X64 ")", LeftExpr, LeftValue, LeftValue, RightExpr, RightValue, RightValue);
 
         Result = RESOLVBUS_ERROR_UNKNOWN;
         ResolVBus_ResetBacktrace(Message, "<see above>", __FILE__, __LINE__, __func__);

--- a/test/TestMain.c
+++ b/test/TestMain.c
@@ -136,6 +136,21 @@ RESOLVBUS_RESULT AssertEql(int64_t LeftValue, const char *LeftExpr, int64_t Righ
     return Result;
 }
 
+RESOLVBUS_RESULT AssertNotEql(int64_t LeftValue, const char *LeftExpr, int64_t RightValue, const char *RightExpr)
+{
+    RESOLVBUS_RESULT Result = RESOLVBUS_OK;
+
+    if (LeftValue == RightValue) {
+        static char Message [1024] = { 0 };
+        snprintf(Message, sizeof (Message), "Expected values not to equal\n  Left:  %s = %lld (0x%llx)\n  Right: %s = %lld (0x%llx)", LeftExpr, LeftValue, LeftValue, RightExpr, RightValue, RightValue);
+
+        Result = RESOLVBUS_ERROR_UNKNOWN;
+        ResolVBus_ResetBacktrace(Message, "<see above>", __FILE__, __LINE__, __func__);
+    }
+
+    return Result;
+}
+
 
 RESOLVBUS_RESULT AssertStringEql(const char *LeftValue, const char *LeftExpr, const char *RightValue, const char *RightExpr)
 {

--- a/test/Testing.h
+++ b/test/Testing.h
@@ -41,6 +41,10 @@
     __WRAP_SHORT(AssertEql(__Left__, #__Left__, __Right__, #__Right__)); \
 
 
+#define __ASSERT_NOT_EQL(__Left__, __Right__) \
+    __WRAP_SHORT(AssertNotEql(__Left__, #__Left__, __Right__, #__Right__)); \
+
+
 #define __ASSERT_RESULT_EQL(__ErrorSuffix__, __ErrorMessage__, __Result__) \
     __WRAP_SHORT(AssertResultEql(RESOLVBUS_ERROR_##__ErrorSuffix__, __ErrorMessage__, __Result__)); \
 
@@ -85,6 +89,7 @@ extern const uint8_t TestData_Live2 [17];
 
 void AppendToLog(char *Log, size_t Length, const char *Format, ...);
 RESOLVBUS_RESULT AssertEql(int64_t LeftValue, const char *LeftExpr, int64_t RightValue, const char *RightExpr);
+RESOLVBUS_RESULT AssertNotEql(int64_t LeftValue, const char *LeftExpr, int64_t RightValue, const char *RightExpr);
 RESOLVBUS_RESULT AssertStringEql(const char *LeftValue, const char *LeftExpr, const char *RightValue, const char *RightExpr);
 RESOLVBUS_RESULT AssertResultEql(RESOLVBUS_RESULT ExpectedResult, const char *ExpectedMessage, RESOLVBUS_RESULT ActualResult);
 


### PR DESCRIPTION
Hey @Rapp2!

Thank you for your improvement patch! I ported it to the current version and made some modifications:

- I refactored the way the struct initializers work to improve future compatibility
- I made a small change to the "short frame data buffer" test. It now uses a larger buffer, but only registers a small part of it. Reason was that I was not sure whether there was any guarantee that your two buffers would sit right next to each other on all platforms
- I removed the suspend test since it failed after the recently discussed changes and the code was already covered by another test

Please have a look whether you can agree to that modifications. Otherwise feel free to either comment or commit additional changes.

Thanks again!
Daniel

